### PR TITLE
Fix loop test for MPI and add -t for cycles test

### DIFF
--- a/applications/loop-suite/3.loop-fork-cycles/Makefile
+++ b/applications/loop-suite/3.loop-fork-cycles/Makefile
@@ -2,6 +2,6 @@ TARGET=loop
 
 COMPILER=gcc
 COMPILER_ARGS=-g -O2
-MEASUREMENT_ARGS=-e cycles
+MEASUREMENT_ARGS=-t -e cycles
 
 include ../include/Makefile

--- a/applications/loop-suite/4.loop-mpi-cycles/Makefile
+++ b/applications/loop-suite/4.loop-mpi-cycles/Makefile
@@ -2,6 +2,8 @@ TARGET=loop
 
 COMPILER=mpicc
 COMPILER_ARGS=-g -O2 -DMPI
-MEASUREMENT_ARGS=-e cycles
+MEASUREMENT_ARGS=-t -e cycles
+
+LAUNCHER=mpirun -np 2
 
 include ../include/Makefile

--- a/applications/loop-suite/4.loop-mpi-cycles/loop.c
+++ b/applications/loop-suite/4.loop-mpi-cycles/loop.c
@@ -3,7 +3,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-void test_mpi(int world_size, world_rank, long n)
+void test_mpi(int world_size, int world_rank, long n)
 {
   loop(n);
 }

--- a/applications/loop-suite/7.loop-openmp-cycles/Makefile
+++ b/applications/loop-suite/7.loop-openmp-cycles/Makefile
@@ -2,6 +2,6 @@ TARGET=loop
 
 COMPILER=gcc
 COMPILER_ARGS=-g -O2 -fopenmp
-MEASUREMENT_ARGS=-e cycles
+MEASUREMENT_ARGS=-t -e cycles
 
 include ../include/Makefile

--- a/applications/loop-suite/8.loop-fork-exec-cycles/Makefile
+++ b/applications/loop-suite/8.loop-fork-exec-cycles/Makefile
@@ -1,6 +1,6 @@
 COMPILER=gcc
 COMPILER_ARGS=-g -O2
-MEASUREMENT_ARGS=-e cycles
+MEASUREMENT_ARGS=-t -e cycles
 
 
 all: child loop.d
@@ -11,5 +11,6 @@ child:
 clean::
 	make -f Makefile.child clean
 
+LAUNCHER=mpirun  -np 2
 TARGET=loop
 include ../include/Makefile

--- a/applications/loop-suite/include/Makefile
+++ b/applications/loop-suite/include/Makefile
@@ -3,7 +3,7 @@ $(TARGET).d: $(TARGET).m
 	hpcprof -o $@ $<
 
 $(TARGET).m: $(TARGET)
-	hpcrun $(MEASUREMENT_ARGS) -o $@ ./$<
+	${LAUNCHER} hpcrun $(MEASUREMENT_ARGS) -o $@ ./$<
 
 $(TARGET): $(TARGET).c
 	$(COMPILER) $(COMPILER_ARGS) -o $@ $<

--- a/applications/loop-suite/include/common.h
+++ b/applications/loop-suite/include/common.h
@@ -7,19 +7,17 @@
 
 #define N (1L << 30)
 
-void loop(long n)
-{
-   volatile long i;
-   for(i = 0; i < n; i++);
-}
-
-
 #ifdef MPI
 void test_mpi(int world_size, int world_rank, long n);
 #else
 void test(long n);
 #endif
 
+void loop(long n)
+{
+   volatile long i;
+   for(i = 0; i < n; i++);
+}
 
 long parse(int argc, char **argv)
 {

--- a/applications/loop-suite/include/common.h
+++ b/applications/loop-suite/include/common.h
@@ -13,9 +13,11 @@ void loop(long n)
    for(i = 0; i < n; i++);
 }
 
-void test(long n);
+
 #ifdef MPI
 void test_mpi(int world_size, int world_rank, long n);
+#else
+void test(long n);
 #endif
 
 

--- a/applications/loop-suite/include/common.h
+++ b/applications/loop-suite/include/common.h
@@ -14,6 +14,10 @@ void loop(long n)
 }
 
 void test(long n);
+#ifdef MPI
+void test_mpi(int world_size, int world_rank, long n);
+#endif
+
 
 long parse(int argc, char **argv)
 {
@@ -47,7 +51,7 @@ int main(int argc, char **argv)
    long n = parse(argc, argv);
 
 #ifdef MPI
-   test_mpi(world_size, workd_rank, n);
+   test_mpi(world_size, world_rank, n);
 #else
    test(n);
 #endif


### PR DESCRIPTION
The original mpi test causes errors in compilation and hang when running.
We need to add mpirun when profiling mpi app

minor update: add -t when profiling perf_events just to see the traces